### PR TITLE
prevent undefined method in valid? from nil twid

### DIFF
--- a/lib/taiwanese_id_validator/twid_validator.rb
+++ b/lib/taiwanese_id_validator/twid_validator.rb
@@ -2,6 +2,8 @@ require 'taiwanese_id_validator/twid_mapping'
 
 module TwidValidator
   def self.valid?(twid, case_sensitive = true)
+    return false if !twid
+
     twid = twid.upcase unless case_sensitive
 
     return false if twid.length != 10


### PR DESCRIPTION
當使用 `shoulda-matchers` 套件輔助 rspec expectation 時 `it { is_expected.to validate_presence_of(:id_card_number) }`，該套件會將正確的值跟不正確甚至是nil帶入預測試欄位進行驗證。當它把 nil 帶進去驗證時，TwidValidator 的 valid? 的 value 是 nil，這時執行 `return false if twid.length != 10` 就會出現錯誤：`undefined method 'length' for nil:NilClass`。